### PR TITLE
Fix Express product routes ordering and ID validation

### DIFF
--- a/routes/products.js
+++ b/routes/products.js
@@ -8,15 +8,15 @@ router.get('/', async (req, res) => {
     const products = await db.select('*').from('products');
     res.json(products);
   } catch (err) {
-  console.error('Error al obtener productos:', {
-    message: err.message,
-    code: err.code,
-    errno: err.errno,
-    sqlState: err.sqlState,
-    sqlMessage: err.sqlMessage
-  });
-  res.status(500).json({ error: 'Error interno del servidor' });
-}
+    console.error('Error al obtener productos:', {
+      message: err.message,
+      code: err.code,
+      errno: err.errno,
+      sqlState: err.sqlState,
+      sqlMessage: err.sqlMessage
+    });
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
 });
 
 // 🟡 GET /products/categories → resumen por categoría
@@ -29,15 +29,15 @@ router.get('/categories', async (req, res) => {
 
     res.json(results);
   } catch (err) {
-  console.error('Error al obtener productos:', {
-    message: err.message,
-    code: err.code,
-    errno: err.errno,
-    sqlState: err.sqlState,
-    sqlMessage: err.sqlMessage
-  });
-  res.status(500).json({ error: 'Error interno del servidor' });
-}
+    console.error('Error al obtener productos:', {
+      message: err.message,
+      code: err.code,
+      errno: err.errno,
+      sqlState: err.sqlState,
+      sqlMessage: err.sqlMessage
+    });
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
 });
 
 // 🟢 GET /products/price-by-category → total de precios por categoría
@@ -55,22 +55,6 @@ router.get('/price-by-category', async (req, res) => {
   }
 });
 
-
-// 🟢 GET /products/:id → producto por ID
-router.get('/:id', async (req, res) => {
-  const { id } = req.params;
-  try {
-    const product = await db('products').where({ id }).first();
-    if (product) {
-      res.json(product);
-    } else {
-      res.status(404).json({ error: 'Producto no encontrado' });
-    }
-  } catch (err) {
-    console.error('Error al obtener producto:', err);
-    res.status(500).json({ error: 'Error interno del servidor' });
-  }
-});
 
 // 🟢 GET /products/categories/summary → total y porcentaje por categoría
 router.get('/categories/summary', async (req, res) => {
@@ -91,6 +75,27 @@ router.get('/categories/summary', async (req, res) => {
     res.json(enriched);
   } catch (err) {
     console.error('Error al obtener resumen de precios por categoría:', err);
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
+// 🟢 GET /products/:id → producto por ID
+router.get('/:id', async (req, res) => {
+  const id = Number(req.params.id);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return res.status(400).json({ error: 'ID inválido' });
+  }
+
+  try {
+    const product = await db('products').where({ id }).first();
+    if (product) {
+      res.json(product);
+    } else {
+      res.status(404).json({ error: 'Producto no encontrado' });
+    }
+  } catch (err) {
+    console.error('Error al obtener producto:', err);
     res.status(500).json({ error: 'Error interno del servidor' });
   }
 });

--- a/server/index.js
+++ b/server/index.js
@@ -19,16 +19,16 @@ app.use((req, res, next) => {
   next();
 });
 
+// 👉 Servir frontend
+const staticDir = path.join(__dirname, '..', 'frontend', 'dist');
+app.use(express.static(staticDir));
+
 // Rutas API
 const productRoutes = require('../routes/products');
 app.use('/products', productRoutes);
 
 // Healthcheck
 app.get('/health', (req, res) => res.status(200).send('OK'));
-
-// 👉 Servir frontend
-const staticDir = path.join(__dirname, '..', 'frontend', 'dist');
-app.use(express.static(staticDir));
 
 // Fallback SPA (React Router)
 app.get('*', (req, res) => {


### PR DESCRIPTION
## Summary
- serve the built frontend before API routes while keeping the SPA fallback at the end
- reorder product route definitions so static paths resolve before the dynamic :id handler
- replace the path-to-regexp pattern for the product ID with runtime validation to avoid startup errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb51e65d88326b95ec82d8e2bf3e3