### PR TITLE
Fix Express SPA fallback for Docker container

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,7 @@ app.get('/health', (req, res) => res.status(200).send('OK'));
 
 // Fallback SPA (React Router)
 if (hasFrontendBuild) {
-  app.get('/*', (req, res) => {
+  app.get('*', (req, res) => {
     res.sendFile(indexHtmlPath);
   });
 }


### PR DESCRIPTION
## Summary
- update the SPA fallback route to use the Express 5-compatible catch-all pattern

## Testing
- npm start --silent

------
https://chatgpt.com/codex/tasks/task_e_68cdbd75192c8326ae1bb702905343be